### PR TITLE
Tiny bits

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,11 +56,12 @@ type report struct {
 	executor        executor
 	parameterGetter parameterGetter
 	uploader        uploader
+	bucketName      string
 }
 
-func (r report) setup(session *session.Session) error {
-	bucketName := os.Getenv("BUCKET_NAME")
-	if bucketName == "" {
+func (r *report) setup(session *session.Session) error {
+	r.bucketName = os.Getenv("BUCKET_NAME")
+	if r.bucketName == "" {
 		return errors.New("bucket name not set")
 	}
 
@@ -92,7 +93,6 @@ func (r report) generate(dryRun bool) error {
 }
 
 func (r report) store(session *session.Session, filename string) error {
-	bucketName := os.Getenv("BUCKET_NAME")
 	f, err := os.Open(filename)
 	if err != nil {
 		return fmt.Errorf("failed to open file %q, %v", filename, err)
@@ -101,7 +101,7 @@ func (r report) store(session *session.Session, filename string) error {
 	objectName := fmt.Sprintf("%s-%s", filename, t.Format(time.RFC3339))
 
 	result, err := r.uploader.upload(session, &s3manager.UploadInput{
-		Bucket: aws.String(bucketName),
+		Bucket: aws.String(r.bucketName),
 		Key:    aws.String(objectName),
 		Body:   f,
 	})

--- a/main.go
+++ b/main.go
@@ -32,13 +32,13 @@ func HandleLambdaEvent() error {
 
 func runReport(r *report, session *session.Session) error {
 	if err := r.setup(session); err != nil {
-		return fmt.Errorf("Setup error: %v", err)
+		return fmt.Errorf("setup error: %v", err)
 	}
 
 	dryRun, _ := strconv.ParseBool(os.Getenv("GHTOOL_DRY_RUN"))
 
 	if err := r.generate(dryRun); err != nil {
-		return fmt.Errorf("Run error: %v", err)
+		return fmt.Errorf("generate error: %v", err)
 	}
 
 	if dryRun {
@@ -46,7 +46,7 @@ func runReport(r *report, session *session.Session) error {
 	}
 
 	if err := r.store(session, "report.csv"); err != nil {
-		return fmt.Errorf("Store error: %v", err)
+		return fmt.Errorf("store error: %v", err)
 	}
 
 	return nil
@@ -72,7 +72,7 @@ func (r report) setup(session *session.Session) error {
 			WithDecryption: aws.Bool(true),
 		})
 	if err != nil {
-		return fmt.Errorf("Get SSM param failed %v", err)
+		return fmt.Errorf("get SSM param failed %v", err)
 	}
 
 	os.Setenv("GHTOOL_TOKEN", *token.Parameter.Value)

--- a/main.go
+++ b/main.go
@@ -66,11 +66,10 @@ func (r *report) setup(session *session.Session) error {
 		return errors.New("bucket name not set")
 	}
 
-	ssmPath := os.Getenv("TOKEN_PATH")
 	token, err := r.parameterGetter.getParameter(
 		session,
 		&ssm.GetParameterInput{
-			Name:           aws.String(ssmPath),
+			Name:           aws.String(os.Getenv("TOKEN_PATH")),
 			WithDecryption: aws.Bool(true),
 		})
 	if err != nil {
@@ -102,8 +101,8 @@ func (r report) store(session *session.Session, filename string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open file %q, %v", filename, err)
 	}
-	t := time.Now()
-	objectName := fmt.Sprintf("%s-%s", filename, t.Format(time.RFC3339))
+
+	objectName := fmt.Sprintf("%s-%s", filename, time.Now().Format(time.RFC3339))
 
 	result, err := r.uploader.upload(session, &s3manager.UploadInput{
 		Bucket: aws.String(r.bucketName),

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ func Test_runReport(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "Setup error: Get SSM param failed fail",
+			wantErrMsg: "setup error: get SSM param failed fail",
 		},
 		{
 			name: "runReport run failure",
@@ -72,7 +72,7 @@ func Test_runReport(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "Run error: failed to run, got: fail, output: nothing",
+			wantErrMsg: "generate error: failed to run, got: fail, output: nothing",
 		},
 		{
 			name: "runReport dry run exit",
@@ -96,7 +96,7 @@ func Test_runReport(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "Store error: failed to upload file, fail",
+			wantErrMsg: "store error: failed to upload file, fail",
 		},
 	}
 	for _, tt := range tests {
@@ -336,7 +336,7 @@ func TestReport_setup(t *testing.T) {
 			setEnvVar:      true,
 			setEnvVarValue: "some-bucket-id",
 			wantErr:        true,
-			wantErrMsg:     "Get SSM param failed fail",
+			wantErrMsg:     "get SSM param failed fail",
 		},
 		{
 			name:       "Setup throws error bucket not set",


### PR DESCRIPTION
- Lowercase error messages
- Move `bucketName` to `report` struct to avoid calling OS twice 
- Move `dryRun` to properties of `report`
- Inline single-use variables