### PR TITLE
Pin go.mod to 1.15 to be consistent with build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.14 as build
+FROM golang:1.15-alpine3.14 as build
 # cache dependencies
 WORKDIR /app
 # cache dependencies

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine3.14 as base
+FROM golang:1.15-alpine3.14 as base
 RUN apk add --no-cache \
     shadow~=4.8 \
     bash~=5.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hmrc/github-admin-report-lambda
 
-go 1.16
+go 1.15
 
 require (
 	github.com/aws/aws-lambda-go v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Signed-off-by: Tom Roffe <tom@altobyte.io>