### PR TITLE
Update gitignore and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ npm-debug.log
 cover.out
 github-admin-tool
 .vscode
+docker.tar

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ lint-check: golangci-lint
 .PHONY: build-image
 build-image:
 	go mod tidy
-	docker build -t github-admin-report --target distro .
+	docker build -t container-release:local --target distro .
 .PHONY: build-image
 
 .PHONY: build-rie


### PR DESCRIPTION
- Added `docker.tar` to `.gitignore`
- Changed container name to `container-release` tot enable `docker save` command.

Signed-off-by: Tom Roffe <tom@altobyte.io>